### PR TITLE
Bugfix to Access_Request_Generator method _prepare_targets used in from_list_of_tuples for IPv6

### DIFF
--- a/pytos/securechange/helpers.py
+++ b/pytos/securechange/helpers.py
@@ -1059,7 +1059,10 @@ class Access_Request_Generator:
             if target_type == Access_Request_Generator.IPV4_ADDRESS_WITH_MASK:
                 address, netmask = self._split_ipv4_ip_and_netmask(raw_target)
             elif target_type == Access_Request_Generator.IPV6_ADDRESS_WITH_MASK:
-                address, netmask = self._split_ipv4_ip_and_netmask(raw_target)
+                #address, netmask = self._split_ipv4_ip_and_netmask(raw_target)
+                # SecureChange 17.1 expects cidr in address an no netmask for ipv6 networks
+                address = raw_target
+                netmask = None
             elif target_type == Access_Request_Generator.IPV4_ADDRESS:
                 address, netmask = raw_target, "255.255.255.255"
             elif target_type in [Access_Request_Generator.IPV4_ADDRESS_RANGE,


### PR DESCRIPTION
SecureChange 17.1 API expects cidr in address an no netmask for ipv6 networks
Tufin might fix it in the API some time. Then this fix will rather be a bug. But as the API is not versioned this results in unknown behaviour.

Example
```
<destinations>
    <destination type="IP">
        <id/>
        <ip_address>2a03:1e80:a01::</ip_address>
        <netmask>96</netmask>
```
Leads to 
?xml version="1.0" encoding="UTF-8" standalone="yes"?><result><code>FIELD_VALIDATION_ERROR</code><message>Invalid value for field: Required Access:  (Invalid IP network 2a03:1e80:a01::/96)</message></result>