### PR TITLE
Add ZEROFILL flag, strip leading zeros for netaddr

### DIFF
--- a/pytos/common/functions/network.py
+++ b/pytos/common/functions/network.py
@@ -138,7 +138,7 @@ def get_ip_subnets(ip):
         return [netaddr.IPNetwork(ip)]
     elif "-" in ip:
         start_ip, end_ip = ip.split("-")
-        ip_set_object = netaddr.IPSet(netaddr.IPRange(start_ip, end_ip))
+        ip_set_object = netaddr.IPSet(netaddr.IPRange(start_ip, end_ip, flags=netaddr.ZEROFILL))
         return [address for address in ip_set_object.iter_cidrs()]
     else:
         if is_ipv4_string(ip):

--- a/pytos/securetrack/xml_objects/rest/rules.py
+++ b/pytos/securetrack/xml_objects/rest/rules.py
@@ -1002,7 +1002,7 @@ class Subnet_Network_Object(Network_Object):
         return "{}/{}".format(self.ip, self.netmask)
 
     def as_netaddr_obj(self):
-        return netaddr.IPNetwork("{}/{}".format(self.ip, '.'.join(int(o) for o in self.netmask.split('.'))))
+        return netaddr.IPNetwork("{}/{}".format(self.ip, '.'.join(str(int(o)) for o in self.netmask.split('.'))))
 
 
 class Base_Network_Object(Network_Object):

--- a/pytos/securetrack/xml_objects/rest/rules.py
+++ b/pytos/securetrack/xml_objects/rest/rules.py
@@ -1002,7 +1002,7 @@ class Subnet_Network_Object(Network_Object):
         return "{}/{}".format(self.ip, self.netmask)
 
     def as_netaddr_obj(self):
-        return netaddr.IPNetwork("{}/{}".format(self.ip, '.'.join(int(o for o in self.netmask.split('.'))))
+        return netaddr.IPNetwork("{}/{}".format(self.ip, '.'.join(int(o) for o in self.netmask.split('.'))))
 
 
 class Base_Network_Object(Network_Object):

--- a/pytos/securetrack/xml_objects/rest/rules.py
+++ b/pytos/securetrack/xml_objects/rest/rules.py
@@ -871,7 +871,7 @@ class Range_Network_Object(Network_Object):
         return "{}-{}".format(self.first_ip, self.last_ip)
 
     def as_netaddr_obj(self):
-        return netaddr.IPRange(self.first_ip, self.last_ip)
+        return netaddr.IPRange(self.first_ip, self.last_ip, flags=netaddr.ZEROFILL)
 
 
 class Host_Network_Object(Network_Object):
@@ -1002,7 +1002,7 @@ class Subnet_Network_Object(Network_Object):
         return "{}/{}".format(self.ip, self.netmask)
 
     def as_netaddr_obj(self):
-        return netaddr.IPNetwork("{}/{}".format(self.ip, self.netmask))
+        return netaddr.IPNetwork("{}/{}".format(self.ip, '.'.join(int(o for o in self.netmask.split('.'))))
 
 
 class Base_Network_Object(Network_Object):
@@ -1972,7 +1972,7 @@ class TrafficRange(XML_Object_Base):
         if self.src.from_ == self.src.to:
             src = netaddr.IPNetwork(self.src.from_)
         else:
-            src = netaddr.IPRange(self.src.from_, self.src.to)
+            src = netaddr.IPRange(self.src.from_, self.src.to, flags=netaddr.ZEROFILL)
         return src
 
     def as_netaddr_set(self):


### PR DESCRIPTION
This PR addresses an API issue that allows Fortinet network objects
to be returned with leading zeros in each octect of the IP and/or mask