### PR TITLE
as_netaddr_obj ST fix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 CHANGES
 =======
 
+1.0.1
+* Fixed a bug that causes issues with as_netaddr_obj() for Fortinet network objects
+
+
 1.0.0
 =====
 

--- a/pytos/__init__.py
+++ b/pytos/__init__.py
@@ -1,3 +1,3 @@
 
 __author__ = "PS-Solutions"
-__version__ = "1.0.0"
+__version__ = "1.0.1"

--- a/pytos/common/functions/network.py
+++ b/pytos/common/functions/network.py
@@ -138,7 +138,7 @@ def get_ip_subnets(ip):
         return [netaddr.IPNetwork(ip)]
     elif "-" in ip:
         start_ip, end_ip = ip.split("-")
-        ip_set_object = netaddr.IPSet(netaddr.IPRange(start_ip, end_ip))
+        ip_set_object = netaddr.IPSet(netaddr.IPRange(start_ip, end_ip, flags=netaddr.ZEROFILL))
         return [address for address in ip_set_object.iter_cidrs()]
     else:
         if is_ipv4_string(ip):

--- a/pytos/securetrack/xml_objects/rest/rules.py
+++ b/pytos/securetrack/xml_objects/rest/rules.py
@@ -871,7 +871,7 @@ class Range_Network_Object(Network_Object):
         return "{}-{}".format(self.first_ip, self.last_ip)
 
     def as_netaddr_obj(self):
-        return netaddr.IPRange(self.first_ip, self.last_ip)
+        return netaddr.IPRange(self.first_ip, self.last_ip, flags=netaddr.ZEROFILL)
 
 
 class Host_Network_Object(Network_Object):
@@ -1002,7 +1002,7 @@ class Subnet_Network_Object(Network_Object):
         return "{}/{}".format(self.ip, self.netmask)
 
     def as_netaddr_obj(self):
-        return netaddr.IPNetwork("{}/{}".format(self.ip, self.netmask))
+        return netaddr.IPNetwork("{}/{}".format(self.ip, '.'.join(str(int(o)) for o in self.netmask.split('.'))))
 
 
 class Base_Network_Object(Network_Object):
@@ -1972,7 +1972,7 @@ class TrafficRange(XML_Object_Base):
         if self.src.from_ == self.src.to:
             src = netaddr.IPNetwork(self.src.from_)
         else:
-            src = netaddr.IPRange(self.src.from_, self.src.to)
+            src = netaddr.IPRange(self.src.from_, self.src.to, flags=netaddr.ZEROFILL)
         return src
 
     def as_netaddr_set(self):

--- a/pytos/securetrack/xml_objects/rest/rules.py
+++ b/pytos/securetrack/xml_objects/rest/rules.py
@@ -1970,7 +1970,7 @@ class TrafficRange(XML_Object_Base):
 
     def as_netaddr_obj(self):
         if self.src.from_ == self.src.to:
-            src = netaddr.IPNetwork(self.src.from_)
+            src = netaddr.IPNetwork(self.src.from_, flags=netaddr.ZEROFILL)
         else:
             src = netaddr.IPRange(self.src.from_, self.src.to, flags=netaddr.ZEROFILL)
         return src


### PR DESCRIPTION
This PR corrects an issue with Fortimanager objects returns from ST with leading zero padded masks and ip addresses. It strips leading 0s from masks, and adds the ZEROFILL flag to other netaddr operations.